### PR TITLE
Fix geolocation error handling

### DIFF
--- a/src/components/DataWrapper.js
+++ b/src/components/DataWrapper.js
@@ -2,18 +2,25 @@ import React, { Component } from 'react';
 import DataItemContainer from './../containers/DataItemContainer';
 import StatusItem from './StatusItem';
 import location from './../utils/location';
+import weather from './../utils/weather';
 
 class DataWrapper extends Component {
   constructor(props) {
     super(props);
 
-    this.props.updateLoaderStatus('Getting your location');
     location().then((position) => {
       this.props.updateLocation(position);
       this.props.updateLoaderStatus('Located');
     }).catch((e) => {
-      this.props.updateLoaderStatus('Unable to get your location');
-      this.props.updateLoaderError(true);
+      if (typeof e === 'string') {
+        // If client doesn't support geolocation (see src/utils/location.js)
+        this.props.updateLoaderStatus(e);
+        this.props.updateLoaderError(true);
+      } else {
+        // If geolocation fails for some other reason
+        this.props.updateLoaderStatus('Unable to get your location');
+        this.props.updateLoaderError(true);
+      }
     });
 
     // Make API requests


### PR DESCRIPTION
If geolocation fails because the client doesn't support geolocation,
location.js rejects the promise with a string.

Previously, DataWrapper ignores this string and substitutes its own
error message. This commit fixes that. DataWrapper will only load
its own error message if geolocation is supported but fails otherwise.