### PR TITLE
Fix bug (reducers reinitializing values)

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -26,21 +26,25 @@ const loader = (state, action) => {
       });
   
     default:
-      return {
-        loaded: false,
-        status: 'Loading',
-        error: false
-      };
+      if (state === undefined) {
+        return {
+          loaded: false,
+          status: 'Loading',
+          error: false
+        };
+      }
+
+      return state;
   }
 };
 
-const location = (state, action) => {
-  return action.type === UPDATE_LOCATION ? action.position : null;
+const location = (state = null, action) => {
+  return action.type === UPDATE_LOCATION ? action.position : state;
 };
 
-export const payload = (state, action) => {
+export const payload = (state = {}, action) => {
   if (action.type !== UPDATE_PAYLOAD) {
-    return {};
+    return state;
   }
 
   let res = Object.assign({}, state);


### PR DESCRIPTION
Previously, reducers will return the default (initialized) values when
the action type doesn't trigger any of its cases, which is incorrect.
This commit fixes this so that reducers will only do so when received
state is undefined (initialization), but will return the received state
in every other case (no more reinitialization of values).